### PR TITLE
fix (resume): remove resume title

### DIFF
--- a/cv-ruebenramirez.md
+++ b/cv-ruebenramirez.md
@@ -1,4 +1,4 @@
-## Rueben Ramirez
+# Rueben Ramirez
 Austin, TX | ruebenramirez@gmail.com | [GitHub](https://github.com/ruebenramirez) | [Blog](https://blog.rueb.dev/)
 
 ## Executive Summary

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
               -t html \
               -o "$BASE_NAME.html" \
               --standalone \
-              --metadata title="Resume" \
+              --metadata title="" \
               --css=https://cdn.jsdelivr.net/npm/water.css@2/out/water.css \
               --self-contained
 


### PR DESCRIPTION
remove the extra "Resume" title at the top of the document